### PR TITLE
Use a proper version for the bnd gradle plugin dependency

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 bnd_cnf=cnf
 
 # bnd_plugin is the dependency declaration for the bnd gradle plugin
-bnd_plugin=biz.aQute.bnd:biz.aQute.bnd.gradle:${bndlib-version-base}
+bnd_plugin=biz.aQute.bnd:biz.aQute.bnd.gradle:2.4.1
 
 # bnd_build can be set to the name of a "master" project whose dependencies will seed the set of projects to build.
 bnd_build=


### PR DESCRIPTION
The file seems to have been copied from the source code of bndtools. But the file is meant to be processed during the bndtools build to replace the macro with an actual version number.

I used the latest release version here.

Signed-off-by: BJ Hargrave bj@bjhargrave.com
